### PR TITLE
FDP-3267 ~ Ignores stop self test result

### DIFF
--- a/src/integrationTest/kotlin/org/lfenergy/gxf/protocol/adapter/oslp/mikronika/command/StopSelfTestCommandIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/lfenergy/gxf/protocol/adapter/oslp/mikronika/command/StopSelfTestCommandIntegrationTest.kt
@@ -63,7 +63,6 @@ class StopSelfTestCommandIntegrationTest : CommandIntegrationTest() {
 
         assertNotNull(result)
         assertEquals(Result.NOT_OK, result.result)
-        assertEquals(123.toChar().toString(), result.errorResponse.errorMessage)
 
         val receivedRequest = rejectedMock.capturedRequest.get()
 

--- a/src/main/kotlin/org/lfenergy/gxf/protocol/adapter/oslp/mikronika/command/mapper/StopSelfTestCommandMapper.kt
+++ b/src/main/kotlin/org/lfenergy/gxf/protocol/adapter/oslp/mikronika/command/mapper/StopSelfTestCommandMapper.kt
@@ -14,7 +14,6 @@ import org.lfenergy.gxf.publiclighting.contracts.internal.device_requests.Device
 import org.lfenergy.gxf.publiclighting.contracts.internal.device_requests.RequestHeader
 import org.lfenergy.gxf.publiclighting.contracts.internal.device_responses.DeviceResponseMessage
 import org.lfenergy.gxf.publiclighting.contracts.internal.device_responses.deviceResponseMessage
-import org.lfenergy.gxf.publiclighting.contracts.internal.device_responses.errorResponse
 import org.opensmartgridplatform.oslp.Oslp
 import org.springframework.stereotype.Component
 import org.lfenergy.gxf.publiclighting.contracts.internal.device_responses.Result as InternalResult
@@ -42,12 +41,5 @@ class StopSelfTestCommandMapper : CommandMapper {
                     Oslp.Status.OK -> InternalResult.OK
                     else -> InternalResult.NOT_OK
                 }
-
-            if (response.hasSelfTestResult()) {
-                errorResponse =
-                    errorResponse {
-                        errorMessage = response.selfTestResult.toStringUtf8()
-                    }
-            }
         }
 }


### PR DESCRIPTION
self test result is always returned, also on success, writing it to the errorResponse causes the stop self test to fail.